### PR TITLE
Non-idempotent Function test-remove() Fix

### DIFF
--- a/devtracker/test_devtracker.py
+++ b/devtracker/test_devtracker.py
@@ -153,6 +153,7 @@ January  2, 1999 | 12:00 AM   | January  2, 1999 | 12:00 AM | 00:00:01 |
 
 
 def test_remove():
-    os.remove(path)
+    if os.path.isfile(path):
+        os.remove(path)
 
 


### PR DESCRIPTION
This PR aims to fix the non-idempotency of test-remove() by providing a check to confirm whether the given path is valid. 

The test passes once and fails once (is non-idempotent) when running `pytest --count=2 devtracker/test_devtracker.py::test_remove`.

It may be better to add the check in order to make the test pass multiple times.